### PR TITLE
Added "copy" button

### DIFF
--- a/src/main/java/link/infra/screenshotclipboard/ScreenshotToClipboard.java
+++ b/src/main/java/link/infra/screenshotclipboard/ScreenshotToClipboard.java
@@ -40,7 +40,8 @@ public class ScreenshotToClipboard {
 	private static int savedWidth;
 	private static int savedHeight;
 	private static ScreenshotEvent savedEvent;
-	
+	//TODO: All one line.
+	//TODO: Copy that specific screenshot?
 	
 	@SubscribeEvent
 	public void handleChat(ClientChatEvent event)
@@ -61,7 +62,6 @@ public class ScreenshotToClipboard {
 			
 			Style copiedStyle = new Style();
 			copiedStyle.setColor(TextFormatting.GREEN);
-			copiedStyle.setBold(true);
 			
 			StringTextComponent copiedText = new StringTextComponent("copied!");
 			copiedText.setStyle(copiedStyle);
@@ -100,14 +100,17 @@ public class ScreenshotToClipboard {
 		yesStyle.setBold(true);
 		yesStyle.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/copyscreenshot"));
 		
-		StringTextComponent hoverText = new StringTextComponent("Click to copy screenshot");
-		Style hoverStyle = new Style();
-		hoverStyle.setColor(TextFormatting.WHITE);
-		hoverText.setStyle(hoverStyle);
+		StringTextComponent hoverText = new StringTextComponent("Click to copy ");
+		StringTextComponent latest = new StringTextComponent("latest");
+		latest.setStyle(new Style().setBold(true));
+		StringTextComponent hoverText2 = new StringTextComponent(" screenshot");
+		
+		hoverText.appendSibling(latest);
+		hoverText.appendSibling(hoverText2);
 		
 		yesStyle.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverText));
 		
-		StringTextComponent base = new StringTextComponent("Screenshot taken!\nCopy to clipboard: ");
+		StringTextComponent base = new StringTextComponent("Screenshot taken! ");
 		StringTextComponent yes = new StringTextComponent("[Copy]");
 		yes.setStyle(yesStyle);
 		

--- a/src/main/java/link/infra/screenshotclipboard/ScreenshotToClipboard.java
+++ b/src/main/java/link/infra/screenshotclipboard/ScreenshotToClipboard.java
@@ -40,8 +40,6 @@ public class ScreenshotToClipboard {
 	private static int savedWidth;
 	private static int savedHeight;
 	private static ScreenshotEvent savedEvent;
-	//TODO: All one line.
-	//TODO: Copy that specific screenshot?
 	
 	@SubscribeEvent
 	public void handleChat(ClientChatEvent event)


### PR DESCRIPTION
Hello! I saw that you seem really friendly and active, so I figured I'd give this a shot...

The 1.8 mod [Vanilla Enhancements](https://www.curseforge.com/minecraft/mc-mods/vanilla-enhancements) had an improved screenshot chat message, [letting you choose](https://i.imgur.com/5VVlP8L.png) to copy it to clipboard. I wanted this functionality in 1.15, and I found your mod.

I spent some time adding this sort of functionality to your Forge 1.15 version (hooray for open-source!)—you can see what it looks like below. I was originally going to keep it for myself because I didn't want to distribute your code, but maybe you might be interested in it.

I'm not a professional programmer—I'm a self-taught hobbyist and don't have a ton of experience. I feel like storing the image and event in variables (like I did) isn't the best solution, but it only stores one at a time, so I can't imagine it's *that* big of a deal. If you want to take a stab at it and find a better way be my guest! Also, it can only copy the latest screenshot—I'm not going to try to write code to look up the image.

I don't expect you to merge this PR, but I wanted to show you it just so you were aware!

If you want the built `.jar`, you can get it [in this release on my fork](https://github.com/TheKingElessar/ScreenshotToClipboard/releases/tag/1.15.1-Copy-Button-updated). Feel free to re-host it here if you wish!

Anyway. Hope you're doing well! Have a nice day.

![](https://i.imgur.com/gdXrYIH.png)